### PR TITLE
Changed shebang and curses now makes the cursor invisible

### DIFF
--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -43,6 +43,7 @@ class Kotnetlogin():
         self.wachtwoord = wachtwoord
         
         self.scherm = curses.initscr()
+        curses.curs_set(0)                  ## cursor invisible
         curses.start_color()                ## Kleuren aanmaken
         curses.noecho()                     ## Toetsen niet afdrukken
         self.scherm.keypad(True)            ## Toetsen laten opvangen door curses


### PR DESCRIPTION
see http://stackoverflow.com/questions/2429511/why-do-people-write-usr-bin-env-python-on-the-first-line-of-a-python-script for a rationale on the 'shebang'

the cursor invisibility is pretty neat I think :-)
