### PR TITLE
Hide blinking cursor in colorama output

### DIFF
--- a/communicator.py
+++ b/communicator.py
@@ -114,8 +114,7 @@ class DialogCommunicator(QuietCommunicator):
                       ])
     
     def eventPingFailure(self):
-        print "Niet verbonden met het KU Leuven-netwerk."
-        ## A dialog should pop up here.
+        self.d.infobox("Niet verbonden met het KU Leuven-netwerk...", 5, 30)
     
     def eventNetloginSuccess(self):
         self.netlogin = self.DONE


### PR DESCRIPTION
Fixed using ANSI escape codes in posix systems

Windows support should still be added if wanted; take a look at [this link](http://stackoverflow.com/a/10455937) which also describes a solution for windows. Added `if os.name == 'posix'` checks so that the code should still work fine on Windows (displaying a blinking cursor)

As with `curses`, all exceptions should call the `beeindig_sessie()` method so that the communicator can restore things nicely...

Also re-added the info dialog for pinging since it seems not to cause the other crashes, as discussed a moment ago
