### PR TITLE
Customizable colorama colors

### DIFF
--- a/communicator/coloramac.py
+++ b/communicator/coloramac.py
@@ -78,7 +78,7 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
         """
         colorama_init()
         cursor.hide()
-        self.init_colors(color.upper())
+        self.init_colors(color)
     
     ## any communicator wanting to customize the colors can override
     ## this method to define new colors and styles
@@ -95,7 +95,7 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
         self.SUCCESS_COLOR = Fore.GREEN
         self.FAIL_STYLE = Style.BRIGHT
         logger.debug("setting self.FAIL_COLOR to %s", colorname)
-        self.FAIL_COLOR = getattr(Fore, colorname) #Fore.RED
+        self.FAIL_COLOR = getattr(Fore, colorname.upper()) #Fore.RED
         self.PERC_STYLE = Style.BRIGHT
         self.CRITICAL_PERC_COLOR = Fore.RED
         self.LOW_PERC_COLOR = Fore.YELLOW

--- a/communicator/coloramac.py
+++ b/communicator/coloramac.py
@@ -76,15 +76,16 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
             Style,                              ## 
             init as colorama_init)              ## 
         """
-        if not (len(colorNameList) == 3):
-            logger.error("given colorNameList %s of length %s should have length 4", \
-            colorNameList, len(colorNameList))
+        try:        
+            colorNameList = map(lambda x:x.upper(), colorNameList)
+            self.init_colors(colorNameList)
+        except Exception, e:
+            logger.error("something went wrong when initializing colors; " + \
+            "did you provide a correct colorNameList %s?", colorNameList)
+            logger.error("exception is: %s" % e)
             exit(1)
-        
-        colorNameList = map(lambda x:x.upper(), colorNameList)
         colorama_init()
         cursor.hide()
-        self.init_colors(colorNameList)
     
     ## any communicator wanting to customize the colors can override
     ## this method to define new colors and styles
@@ -94,18 +95,19 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
     
     def init_colors(self, colorNameList):
         logger.debug("the given colornamelist is %s", colorNameList)
+        style = getattr(Style, colorNameList.pop())
         err_color = getattr(Fore, colorNameList.pop())
         wait_color = getattr(Fore, colorNameList.pop())        
         ok_color = getattr(Fore, colorNameList.pop())
         self.ERR_COLOR = err_color #Fore.RED
-        self.ERR_STYLE = Style.BRIGHT
-        self.WAIT_STYLE = Style.BRIGHT
+        self.ERR_STYLE = style #Style.BRIGHT
+        self.WAIT_STYLE = style #Style.BRIGHT
         self.WAIT_COLOR = wait_color #Fore.YELLOW
-        self.SUCCESS_STYLE = Style.BRIGHT
+        self.SUCCESS_STYLE = style #Style.BRIGHT
         self.SUCCESS_COLOR = ok_color #Fore.GREEN
-        self.FAIL_STYLE = Style.BRIGHT
+        self.FAIL_STYLE = style #Style.BRIGHT
         self.FAIL_COLOR = err_color #Fore.RED
-        self.PERC_STYLE = Style.BRIGHT
+        self.PERC_STYLE = style #Style.BRIGHT
         self.CRITICAL_PERC_COLOR = err_color #Fore.RED
         self.LOW_PERC_COLOR = wait_color #Fore.YELLOW
         self.OK_PERC_COLOR = ok_color #Fore.GREEN

--- a/communicator/coloramac.py
+++ b/communicator/coloramac.py
@@ -49,7 +49,7 @@ try:
     logger.debug("OK")
 except ImportError:
     logger.error("Couldn't import the colorama library.")
-    pass
+    exit(1)
 
 class SuperColoramaCommunicator(SuperPlaintextCommunicator):
     ## I changed the structure: it used to be:
@@ -69,16 +69,22 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
     ## en multiple inheritance van de juiste subplaintext in de subs
     ## Gijs: Merci!
     
-    def __init__(self, color):
+    def __init__(self, colorNameList):
         """
         from colorama import (                  ## Om de tekst kleur te geven
             Fore,                               ## 
             Style,                              ## 
             init as colorama_init)              ## 
         """
+        if not (len(colorNameList) == 3):
+            logger.error("given colorNameList %s of length %s should have length 4", \
+            colorNameList, len(colorNameList))
+            exit(1)
+        
+        colorNameList = map(lambda x:x.upper(), colorNameList)
         colorama_init()
         cursor.hide()
-        self.init_colors(color)
+        self.init_colors(colorNameList)
     
     ## any communicator wanting to customize the colors can override
     ## this method to define new colors and styles
@@ -86,20 +92,23 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
     ##
     ## Gijs: Wat bedoel je? Bvb de balk verbergen, etc?
     
-    def init_colors(self, colorname):
-        self.ERR_COLOR = Fore.RED
+    def init_colors(self, colorNameList):
+        logger.debug("the given colornamelist is %s", colorNameList)
+        err_color = getattr(Fore, colorNameList.pop())
+        wait_color = getattr(Fore, colorNameList.pop())        
+        ok_color = getattr(Fore, colorNameList.pop())
+        self.ERR_COLOR = err_color #Fore.RED
         self.ERR_STYLE = Style.BRIGHT
         self.WAIT_STYLE = Style.BRIGHT
-        self.WAIT_COLOR = Fore.YELLOW
+        self.WAIT_COLOR = wait_color #Fore.YELLOW
         self.SUCCESS_STYLE = Style.BRIGHT
-        self.SUCCESS_COLOR = Fore.GREEN
+        self.SUCCESS_COLOR = ok_color #Fore.GREEN
         self.FAIL_STYLE = Style.BRIGHT
-        logger.debug("setting self.FAIL_COLOR to %s", colorname)
-        self.FAIL_COLOR = getattr(Fore, colorname.upper()) #Fore.RED
+        self.FAIL_COLOR = err_color #Fore.RED
         self.PERC_STYLE = Style.BRIGHT
-        self.CRITICAL_PERC_COLOR = Fore.RED
-        self.LOW_PERC_COLOR = Fore.YELLOW
-        self.OK_PERC_COLOR = Fore.GREEN
+        self.CRITICAL_PERC_COLOR = err_color #Fore.RED
+        self.LOW_PERC_COLOR = wait_color #Fore.YELLOW
+        self.OK_PERC_COLOR = ok_color #Fore.GREEN
 
     ## Overrides the printing of an error string on stderr
     def printerr(self, msg):

--- a/communicator/coloramac.py
+++ b/communicator/coloramac.py
@@ -69,7 +69,7 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
     ## en multiple inheritance van de juiste subplaintext in de subs
     ## Gijs: Merci!
     
-    def __init__(self):
+    def __init__(self, color):
         """
         from colorama import (                  ## Om de tekst kleur te geven
             Fore,                               ## 
@@ -78,7 +78,7 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
         """
         colorama_init()
         cursor.hide()
-        self.init_colors()
+        self.init_colors(color.upper())
     
     ## any communicator wanting to customize the colors can override
     ## this method to define new colors and styles
@@ -86,7 +86,7 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
     ##
     ## Gijs: Wat bedoel je? Bvb de balk verbergen, etc?
     
-    def init_colors(self):
+    def init_colors(self, colorname):
         self.ERR_COLOR = Fore.RED
         self.ERR_STYLE = Style.BRIGHT
         self.WAIT_STYLE = Style.BRIGHT
@@ -94,7 +94,8 @@ class SuperColoramaCommunicator(SuperPlaintextCommunicator):
         self.SUCCESS_STYLE = Style.BRIGHT
         self.SUCCESS_COLOR = Fore.GREEN
         self.FAIL_STYLE = Style.BRIGHT
-        self.FAIL_COLOR = Fore.RED
+        logger.debug("setting self.FAIL_COLOR to %s", colorname)
+        self.FAIL_COLOR = getattr(Fore, colorname) #Fore.RED
         self.PERC_STYLE = Style.BRIGHT
         self.CRITICAL_PERC_COLOR = Fore.RED
         self.LOW_PERC_COLOR = Fore.YELLOW

--- a/communicator/fabriek.py
+++ b/communicator/fabriek.py
@@ -57,9 +57,9 @@ class LoginCommunicatorFabriek(SuperCommunicatorFabriek):
         from plaintextc import LoginPlaintextCommunicator
         return LoginPlaintextCommunicator()
     
-    def createColoramaCommunicator(self, color):
+    def createColoramaCommunicator(self, colorNameList):
         from coloramac import LoginColoramaCommunicator
-        return LoginColoramaCommunicator(color)
+        return LoginColoramaCommunicator(colorNameList)
 
     def createSummaryCommunicator(self):
         return LoginSummaryCommunicator()

--- a/communicator/fabriek.py
+++ b/communicator/fabriek.py
@@ -57,9 +57,9 @@ class LoginCommunicatorFabriek(SuperCommunicatorFabriek):
         from plaintextc import LoginPlaintextCommunicator
         return LoginPlaintextCommunicator()
     
-    def createColoramaCommunicator(self):
+    def createColoramaCommunicator(self, color):
         from coloramac import LoginColoramaCommunicator
-        return LoginColoramaCommunicator()
+        return LoginColoramaCommunicator(color)
 
     def createSummaryCommunicator(self):
         return LoginSummaryCommunicator()

--- a/communicator/fabriek.py
+++ b/communicator/fabriek.py
@@ -49,6 +49,8 @@ class SuperCommunicatorFabriek:
 ## co = co.createColoramaCommunicator() 
 ## co.eventNetloginStart()               ## geeft de juiste output
 
+DEFAULT_COLORAMA_COLORS= [ "green", "yellow", "red", "bright" ]
+
 class LoginCommunicatorFabriek(SuperCommunicatorFabriek):
     #def createQuietCommunicator(self):
     #    return LoginQuietCommunicator()
@@ -57,7 +59,7 @@ class LoginCommunicatorFabriek(SuperCommunicatorFabriek):
         from plaintextc import LoginPlaintextCommunicator
         return LoginPlaintextCommunicator()
     
-    def createColoramaCommunicator(self, colorNameList):
+    def createColoramaCommunicator(self, colorNameList=DEFAULT_COLORAMA_COLORS):
         from coloramac import LoginColoramaCommunicator
         return LoginColoramaCommunicator(colorNameList)
 

--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -143,7 +143,7 @@ class KotnetCLI(object):
         self.communicatorgroep.add_argument("-c", "--color",\
         help="Logs you in using colored text output (default); arguments = ok_color, wait_color, err_color, style",\
         choices= ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "bright", "normal"],
-        nargs=4, default=False, metavar="col")
+        nargs=4, default=False, metavar="COL")
         
         #self.communicatorgroep.add_argument("-q", "--quiet",\
         #help="Hides all output",\

--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -87,12 +87,12 @@ class KotnetCLI(object):
     
     def __init__(self, descr="Script om in- of uit te loggen op KotNet"):
         self.parser = argparse.ArgumentParser(descr)
-        self.workergroep = self.parser.add_argument_group("worker options", \
-        "specify the login action")
-        self.credentialsgroep = self.parser.add_argument_group("credentials options", \
-        "manage your credentials")
-        self.communicatorgroep = self.parser.add_argument_group("communicator options", \
-        "a pluggable visualisation system for everyones needs")
+        self.workergroep = self.parser.add_argument_group("worker options")#, \
+        #"specify the login action")
+        self.credentialsgroep = self.parser.add_argument_group("credentials options")#, \
+        #"manage your credentials")
+        self.communicatorgroep = self.parser.add_argument_group("communicator options") #, \
+        #"a pluggable visualisation system for everyones needs")
         self.voegArgumentenToe()
         argcomplete.autocomplete(self.parser)
     
@@ -143,8 +143,8 @@ class KotnetCLI(object):
         ## default=False to get "store_true" semantics when option not specified
         self.communicatorgroep.add_argument("-c", "--color",\
         help="Logs you in using colored text output (default); arguments = ok_color, wait_color, err_color",\
-        choices= ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"],
-        nargs=3, default=False, metavar="col")
+        choices= ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "bright", "normal"],
+        nargs=4, default=False, metavar="col")
         
         #self.communicatorgroep.add_argument("-q", "--quiet",\
         #help="Hides all output",\

--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -43,7 +43,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 version = "1.3.0-dev"
-DEFAULT_COLORAMA_COLORS= [ "green", "yellow", "red" ]
 
 ## An argument parse action that prints license information
 ## on stdout and exits
@@ -260,14 +259,14 @@ class KotnetCLI(object):
             return fabriek.createPlaintextCommunicator()
         
         elif argumenten.color:
-            logger.info("ik wil vrolijke kleuren: %s", argumenten.color)
+            logger.info("ik wil vrolijke custom kleuren: %s", argumenten.color)
             return fabriek.createColoramaCommunicator(argumenten.color)
         
         else:
             ## default option: argumenten.color
             ## we don't use argparse's mutually exclusive groups so we need a default case here
             logger.info("ik ga mee met de stroom")
-            return fabriek.createColoramaCommunicator(DEFAULT_COLORAMA_COLORS)
+            return fabriek.createColoramaCommunicator()
         
         '''
         elif argumenten.communicator == "summary":

--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -141,7 +141,7 @@ class KotnetCLI(object):
         ## nargs=3 to allow a user to supply optional colorname arguments
         ## default=False to get "store_true" semantics when option not specified
         self.communicatorgroep.add_argument("-c", "--color",\
-        help="Logs you in using colored text output (default); arguments = ok_color, wait_color, err_color",\
+        help="Logs you in using colored text output (default); arguments = ok_color, wait_color, err_color, style",\
         choices= ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "bright", "normal"],
         nargs=4, default=False, metavar="col")
         

--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -183,7 +183,7 @@ class KotnetCLI(object):
         argumenten = self.parser.parse_args()
         ## 0. general flags
         init_debug_level(argumenten.debug)
-        logger.debug("parse_args() is: \n%s", argumenten)
+        logger.debug("parse_args() is: %s", argumenten)
         ## 1. credential-related flags
         creds = self.parseCredentialFlags(argumenten)
         ## 2. login-type flags

--- a/kotnetcli.py
+++ b/kotnetcli.py
@@ -85,7 +85,8 @@ class KotnetCLI(object):
         self.parser = argparse.ArgumentParser(descr)
         self.workergroep = self.parser.add_mutually_exclusive_group()
         self.credentialsgroep = self.parser.add_mutually_exclusive_group()
-        self.communicatorgroep = self.parser.add_mutually_exclusive_group()
+        self.communicatorgroep = self.parser.add_argument_group("communicator options", \
+        "A pluggable visualisation system for everyones needs")
         self.voegArgumentenToe()
         argcomplete.autocomplete(self.parser)
     
@@ -131,12 +132,13 @@ class KotnetCLI(object):
         ## communicator flags
         self.communicatorgroep.add_argument("-c", "--color",\
         help="Logs you in using colored text output (default)",\
-        action="store_const", dest="communicator", const="colortext", \
-        default="colortext")
+        nargs="?", default="False", const="Fore.RED")
+        #action="store_const", dest="communicator", const="colortext", \
+        #default="colortext")
         
         self.communicatorgroep.add_argument("-t", "--plaintext",\
         help="Logs you in using plaintext output",\
-        action="store_const", dest="communicator", const="plaintext")
+        action="store_true") #, dest="communicator", const="plaintext")
 
         
         #self.communicatorgroep.add_argument("-q", "--quiet",\
@@ -177,6 +179,7 @@ class KotnetCLI(object):
         argumenten = self.parser.parse_args()
         ## 0. general flags
         init_debug_level(argumenten.debug)
+        logger.debug("parse_args() is: \n%s", argumenten)
         ## 1. credential-related flags
         creds = self.parseCredentialFlags(argumenten)
         ## 2. login-type flags
@@ -250,13 +253,13 @@ class KotnetCLI(object):
         #    print "ik wil zwijgen"
         #    return fabriek.createQuietCommunicator()
         
-        if argumenten.communicator == "plaintext":
+        if argumenten.plaintext:
             logger.info("ik wil terug naar de basis")
             return fabriek.createPlaintextCommunicator()
         
-        elif argumenten.communicator == "colortext":
-            logger.info("ik wil vrolijke kleuren")
-            return fabriek.createColoramaCommunicator()
+        elif argumenten.color:
+            logger.info("ik wil vrolijke kleuren: %s", argumenten.color)
+            return fabriek.createColoramaCommunicator(argumenten.color)
         
         else:
             logger.info("ik ga mee met de stroom") # TODO kunnen we default niet specifieren mbv argparse module??

--- a/kotnetcli_test.py
+++ b/kotnetcli_test.py
@@ -43,16 +43,17 @@ class KotnetCLITester(KotnetCLI):
     
     ## override with dummy behavior
     def parseActionFlags(self, argumenten):
-        if argumenten.worker == "login":
+        if argumenten.logout:
+            logger.info("ik wil uitloggen voor spek en bonen")
+            worker = DummyLogoutWorker()
+            fabriek = LogoutCommunicatorFabriek()
+            
+        else:
+            ## default option: argumenten.login
             logger.info("ik wil inloggen voor spek en bonen")
             worker = DummyLoginWorker()
             fabriek = LoginCommunicatorFabriek()
             
-        elif argumenten.worker == "logout":
-            logger.info("ik wil uitloggen voor spek en bonen")
-            worker = DummyLogoutWorker()
-            fabriek = LogoutCommunicatorFabriek()
-        
         return (worker, fabriek)
         
     def parseCredentialFlags(self, argumenten):

--- a/kotnetcli_test.py
+++ b/kotnetcli_test.py
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 class KotnetCLITester(KotnetCLI):
 
     def __init__(self):
-        super(KotnetCLITester, self).__init__("[DUMMY] script \
-        om in- of uit te loggen op KotNet")
+        super(KotnetCLITester, self).__init__("dummy script " + \
+        "om in- of uit te loggen op KotNet")
 
     def voegArgumentenToe(self):
         super(KotnetCLITester, self).voegArgumentenToe()


### PR DESCRIPTION
allows a user to specify custom colors and style for the `Colorama` communicator via optional cli arguments:

```bash
# arguments = ok_color, wait_color, err_color, style
./kotnetcli.py -c green cyan yellow normal -d
```

The implementation also serves as a proof-of-concept on how to customize communicators without sacrificing cohesion and separation of concerns. This is done using constructor arguments passed through the factory, allowing the front-end to get the parameters from the user in any way. Here it's done through cli arguments; analogously it can be done through a GUI, config file, etc.

Note that, to support multiple command line arguments, I had to let go the [`add_mutually_exclusive_group()`](https://docs.python.org/2/library/argparse.html#mutual-exclusion). While my solution doesn't report an error on adding multiple conflicting options (for now), it only executes one option (as defined by the `elif` switches) and furthermore allows grouping in the help messages:

> Note that currently mutually exclusive argument groups do not support the title and description arguments of add_argument_group().

Lastly, the debug option is improved in that it requires an argument of `choices=[ 'critical', 'error', 'warning', 'info', 'debug' ]` and  defaults to debug if option present but no level specified