### PR TITLE
Python 3 support

### DIFF
--- a/kotnetcli/browser.py
+++ b/kotnetcli/browser.py
@@ -29,7 +29,7 @@ import socket                           ## Voor ophalen IP
 from bs4 import BeautifulSoup, Comment  ## Om webinhoud proper te parsen.
 
 ## login rc codes contained in the response html page
-from server.rccodes import *
+from .server.rccodes import *
 
 import logging
 logger = logging.getLogger(__name__)

--- a/kotnetcli/communicator/coloramac.py
+++ b/kotnetcli/communicator/coloramac.py
@@ -22,7 +22,7 @@
 ## along with kotnetcli.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-from plaintextc import AbstractPlaintextCommunicator, LoginPlaintextCommunicator, ForgetPlaintextCommunicator
+from .plaintextc import AbstractPlaintextCommunicator, LoginPlaintextCommunicator, ForgetPlaintextCommunicator
 
 from colorama import (
                       Fore,
@@ -39,7 +39,8 @@ class AbstractColoramaCommunicator(AbstractPlaintextCommunicator):
         self.init_colors(map(lambda x:x.upper(),[ "green", "yellow", "red", "bright" ]))
         colorama_init()
     
-    def init_colors(self, colorNameList):
+    def init_colors(self, colorNameMap):
+        colorNameList = list(colorNameMap)
         style = getattr(Style, colorNameList.pop())
         err_color = getattr(Fore, colorNameList.pop())
         wait_color = getattr(Fore, colorNameList.pop())        
@@ -78,16 +79,16 @@ class AbstractColoramaCommunicator(AbstractPlaintextCommunicator):
         sys.stdout.flush()
 
     def fmt_success(self):
-        print self.SUCCESS_STYLE + "[" + self.SUCCESS_COLOR + self.OK_STR + \
-            Fore.RESET + "]" + Style.RESET_ALL
+        print(self.SUCCESS_STYLE + "[" + self.SUCCESS_COLOR + self.OK_STR + \
+            Fore.RESET + "]" + Style.RESET_ALL)
 
     def fmt_done(self):
-        print self.SUCCESS_STYLE + "[" + self.SUCCESS_COLOR + "DONE" + \
-            Fore.RESET + "]" + Style.RESET_ALL
+        print(self.SUCCESS_STYLE + "[" + self.SUCCESS_COLOR + "DONE" + \
+            Fore.RESET + "]" + Style.RESET_ALL)
 
     def fmt_fail(self):
-        print self.FAIL_STYLE + "[" + self.FAIL_COLOR + "FAIL" + \
-            Fore.RESET + "]" + Style.RESET_ALL
+        print(self.FAIL_STYLE + "[" + self.FAIL_COLOR + "FAIL" + \
+            Fore.RESET + "]" + Style.RESET_ALL)
 
     def fmt_bar(self, percentage):
         if percentage <= 10:

--- a/kotnetcli/communicator/dialogc.py
+++ b/kotnetcli/communicator/dialogc.py
@@ -27,7 +27,7 @@
 from __future__ import unicode_literals
 
 from dialog import Dialog
-from loggerc import LoggerCommunicator
+from .loggerc import LoggerCommunicator
 
 DIALOG_MSG_LOGIN_SUCCESS    = "Je bent successvol ingelogd."
 DIALOG_MSG_FORGET_SUCCESS   = "You have succesfully removed your kotnetcli credentials."
@@ -88,7 +88,7 @@ class SuperNetDialogCommunicator(AbstractDialogCommunicator):
     def eventError(self, string):
         self.info = string
         ## fail the current item and cancel all following ones
-        self.elements[self.iter.next()]      = self.FAIL
+        self.elements[next(self.iter)]      = self.FAIL
         for x in self.iter: self.elements[x] = self.CANCEL
         self.update()
     
@@ -112,7 +112,7 @@ class SuperNetDialogCommunicator(AbstractDialogCommunicator):
         self.update()
     
     def eventGetData(self):
-        self.elements[self.iter.next()] = self.DONE
+        self.elements[next(self.iter)] = self.DONE
         self.overal = 20
         self.update()
     

--- a/kotnetcli/communicator/dialogc.py
+++ b/kotnetcli/communicator/dialogc.py
@@ -117,12 +117,12 @@ class SuperNetDialogCommunicator(AbstractDialogCommunicator):
         self.update()
     
     def eventPostData(self):
-        self.elements[self.iter.next()] = self.DONE
+        self.elements[next(self.iter)] = self.DONE
         self.overal = 50
         self.update()
     
     def eventProcessData(self):
-        self.elements[self.iter.next()] = self.DONE
+        self.elements[next(self.iter)] = self.DONE
         self.overal = 80
         self.update()
 

--- a/kotnetcli/communicator/loggerc.py
+++ b/kotnetcli/communicator/loggerc.py
@@ -21,7 +21,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with kotnetcli.  If not, see <http://www.gnu.org/licenses/>.
 
-from quietc import QuietCommunicator
+from .quietc import QuietCommunicator
 
 import logging
 logger = logging.getLogger(__name__)

--- a/kotnetcli/communicator/plaintextc.py
+++ b/kotnetcli/communicator/plaintextc.py
@@ -24,7 +24,7 @@
 import sys
 import cursor
 
-from quietc import QuietCommunicator
+from .quietc import QuietCommunicator
 
 class AbstractPlaintextCommunicator(QuietCommunicator):
 
@@ -67,13 +67,13 @@ class AbstractPlaintextCommunicator(QuietCommunicator):
         
         aantalStreepjesObvPercentage = int(round(percentagefloat/100.0 * \
                                                     lengteVanBalkfloat))
-        print style + "[" + color + \
+        print(style + "[" + color + \
         "=" * aantalStreepjesObvPercentage + stop_color + \
         " " * (lengteVanBalkint-aantalStreepjesObvPercentage) + \
         "][" + \
         " " * (lengteVanRuimteVoorPercentages - len(percentagestring)) + \
         color + percentagestring + "%" + \
-        stop_color + "]" + stop_style
+        stop_color + "]" + stop_style)
 
     def fmt_bar(self, percentage):
         self.fmt_generic_bar(percentage, "", "", "", "")

--- a/kotnetcli/communicator/quietc.py
+++ b/kotnetcli/communicator/quietc.py
@@ -134,6 +134,8 @@ class QuietCommunicator(object):
     
     def get_input(self, prompt_str, accept=lambda x: x, pwd=False):
         prompt = self.fmt_prompt(prompt_str)
+        try: input = raw_input
+        except NameError: pass
         while True:
             rv = getpass.getpass(prompt) if pwd else input(prompt)
             rv = rv.strip()

--- a/kotnetcli/communicator/quietc.py
+++ b/kotnetcli/communicator/quietc.py
@@ -135,7 +135,7 @@ class QuietCommunicator(object):
     def get_input(self, prompt_str, accept=lambda x: x, pwd=False):
         prompt = self.fmt_prompt(prompt_str)
         while True:
-            rv = getpass.getpass(prompt) if pwd else raw_input(prompt)
+            rv = getpass.getpass(prompt) if pwd else input(prompt)
             rv = rv.strip()
             if accept(rv): break
             print(self.fmt_err(self.err_input))

--- a/kotnetcli/communicator/summaryc.py
+++ b/kotnetcli/communicator/summaryc.py
@@ -21,7 +21,7 @@
 ## You should have received a copy of the GNU General Public License
 ## along with kotnetcli.  If not, see <http://www.gnu.org/licenses/>.
 
-from loggerc import LoggerCommunicator
+from .loggerc import LoggerCommunicator
 
 SUMMARY_MSG_LOGIN       = "Login geslaagd."
 SUMMARY_MSG_DOWN_UP     = "Download: {downl}%, Upload: {upl}%"

--- a/kotnetcli/frontend.py
+++ b/kotnetcli/frontend.py
@@ -38,7 +38,7 @@ from .communicator.fabriek import (
 from .tools import log
 logger = logging.getLogger(__name__)
 
-from __init__ import __version__, __release_name__, __src_url__, __descr__
+from .__init__ import __version__, __release_name__, __src_url__, __descr__
 
 ## Class encapsulating common CLI arguments for all binaries in the kotnetcli
 ## distribution.

--- a/kotnetcli/kotnetcli.py
+++ b/kotnetcli/kotnetcli.py
@@ -44,10 +44,14 @@ from .credentials import (              ## Voor opvragen van s-nummer
 )                                           
 from .worker import (                   ## Stuurt alle losse componenten aan
     LoginWorker,
-    ForgetCredsWorker
+    ForgetCredsWorker,
+    EXIT_FAILURE,
+    EXIT_SUCCESS
 )
 
 from .frontend import AbstractClientFrontEnd
+
+from .__init__ import __src_url__
 
 class KotnetCLI(AbstractClientFrontEnd):
     
@@ -121,7 +125,7 @@ class KotnetCLI(AbstractClientFrontEnd):
         ## 3. communicator-related flags
         try:
             co = self.parseCommunicatorFlags(fabriek, argumenten)
-        except ImportError, e:
+        except ImportError as e:
             logger.error(
                 "import error when trying to create '%s' communicator: %s\n"    \
                 "Have you installed all the dependencies?\n"                    \

--- a/kotnetcli/kotnetgui.py
+++ b/kotnetcli/kotnetgui.py
@@ -25,7 +25,7 @@ import sys
 import threading
 import logging
 from PyQt4 import QtGui, QtCore
-from Queue import Queue
+from queue import Queue
 
 from .communicator.fabriek import inst_dict
 from .communicator.summaryc import AbstractSummaryCommunicator

--- a/kotnetcli/server/server.py
+++ b/kotnetcli/server/server.py
@@ -22,8 +22,8 @@
 ## along with kotnetcli.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import BaseHTTPServer
-import CGIHTTPServer
+import http.server
+from http.server import HTTPServer, CGIHTTPRequestHandler
 import ssl
 import os
 
@@ -50,8 +50,8 @@ class KotnetSrvFrontEnd(AbstractFrontEnd):
 def run_server():
     ## Set up a simple HTTP server that listens for incoming GET/POST requests
     ## and passes them to the relevant CGI script to prepare the HTML response.
-    handler = CGIHTTPServer.CGIHTTPRequestHandler
-    httpd = BaseHTTPServer.HTTPServer((HOST_NAME, PORT_NUMBER), handler)
+    handler = CGIHTTPRequestHandler
+    httpd = HTTPServer((HOST_NAME, PORT_NUMBER), handler)
 
     ## The development test server is intended to run on localhost, so we can
     ## simply use a plain unencrypted HTTP connection. The following lines

--- a/kotnetcli/worker.py
+++ b/kotnetcli/worker.py
@@ -120,24 +120,24 @@ class LoginWorker(SuperNetworkWorker):
         except MaxNumberIPException:
             co.eventFailureMaxIP()
             sys.exit(EXIT_FAILURE)
-        except InvalidInstitutionException, e:
+        except InvalidInstitutionException as e:
             co.eventFailureInstitution(creds.getInst())
             sys.exit(EXIT_FAILURE)
-        except KotNetRegisterException, e:
+        except KotNetRegisterException as e:
             co.eventFailureRegister("KotNet", creds.getUser(),
                 creds.getInst())
             sys.exit(EXIT_FAILURE)
-        except CampusNetRegisterException, e:
+        except CampusNetRegisterException as e:
             co.eventFailureRegister("CampusNet", creds.getUser(),
                 creds.getInst())
             sys.exit(EXIT_FAILURE)
-        except NoLoginServiceException, e:
+        except NoLoginServiceException as e:
             co.eventFailureLoginService()
             sys.exit(EXIT_FAILURE)
         except InternalScriptErrorException:
             co.eventFailureServerScriptError()
             sys.exit(EXIT_FAILURE)
-        except UnknownRCException, e:
+        except UnknownRCException as e:
             (rccode, html) = e.get_info()
             co.eventFailureUnknownRC(rccode, html.encode('utf-8'))
             sys.exit(EXIT_FAILURE)

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ kotnetgui_desktop.write(kotnetgui_desktop_template.format(
 kotnetgui_desktop.close()
 
 import sys
-print sys.prefix
+print(sys.prefix)
 setup(
     name = "kotnetcli",
     packages = find_packages(),
@@ -94,5 +94,3 @@ setup(
         ("/usr/share/icons/", ["kotnetcli/data/kotnetcli.jpg"])
         ]
 )
-
-


### PR DESCRIPTION
This Pull request adds Python 3 support to Kotnetcli. The changes should be compatible with Python2.7, I already tested this to some extend, but please verify. 
Per example, commit afedf0f adds a 'dirty' hack to ensure compatibility with the renaming of raw_input() to input().

Fixes #84.
